### PR TITLE
Add interactive opportunity sorting controls

### DIFF
--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useAppStore } from '../store/useAppStore.ts';
+import { OPPORTUNITY_STATUSES } from '../constants.ts';
 
 import Header from './Header.tsx';
 import Sidebar from './Sidebar.tsx';
@@ -75,6 +76,79 @@ const HomePage: React.FC = () => {
             return true;
         });
     }, [allOpportunities, store.clientSearchQuery, store.advancedFilters]);
+
+    const sortedOpportunities = useMemo(() => {
+        const { field, direction } = store.opportunitySort;
+        const sorted = [...filteredOpportunities];
+        const multiplier = direction === 'asc' ? 1 : -1;
+
+        const compareText = (a?: string | null, b?: string | null) => {
+            const normalizedA = (a || '').toLowerCase();
+            const normalizedB = (b || '').toLowerCase();
+            if (normalizedA === normalizedB) return 0;
+            return normalizedA < normalizedB ? -1 : 1;
+        };
+
+        const getStatusRank = (status: string) => {
+            const index = OPPORTUNITY_STATUSES.indexOf(status as (typeof OPPORTUNITY_STATUSES)[number]);
+            return index === -1 ? OPPORTUNITY_STATUSES.length : index;
+        };
+
+        const parseDeadline = (deadline: string | null) => {
+            if (!deadline) return null;
+            const timestamp = new Date(deadline).getTime();
+            return Number.isNaN(timestamp) ? null : timestamp;
+        };
+
+        sorted.sort((a, b) => {
+            let comparison = 0;
+
+            switch (field) {
+                case 'title':
+                    comparison = compareText(a.Title, b.Title);
+                    break;
+                case 'organization':
+                    comparison = compareText(a.Organization, b.Organization);
+                    break;
+                case 'location':
+                    comparison = compareText(a.Location, b.Location);
+                    break;
+                case 'source':
+                    comparison = compareText(a.Source, b.Source);
+                    break;
+                case 'status':
+                    comparison = getStatusRank(a.status) - getStatusRank(b.status);
+                    break;
+                case 'deadline': {
+                    const aDeadline = parseDeadline(a.Deadline);
+                    const bDeadline = parseDeadline(b.Deadline);
+
+                    if (aDeadline === null && bDeadline === null) {
+                        comparison = 0;
+                    } else if (aDeadline === null) {
+                        comparison = 1;
+                    } else if (bDeadline === null) {
+                        comparison = -1;
+                    } else {
+                        comparison = aDeadline - bDeadline;
+                    }
+                    break;
+                }
+                case 'relevance':
+                default:
+                    comparison = a.Relevance - b.Relevance;
+                    break;
+            }
+
+            if (comparison === 0) {
+                return b.foundAt - a.foundAt;
+            }
+
+            return comparison * multiplier;
+        });
+
+        return sorted;
+    }, [filteredOpportunities, store.opportunitySort]);
 
     const totalOpportunities = useMemo(() => allOpportunities.length, [allOpportunities]);
 
@@ -162,7 +236,7 @@ const HomePage: React.FC = () => {
                                 <AgentPanel />
                             ) : (
                                 totalOpportunities > 0
-                                    ? <OpportunityTable opportunities={filteredOpportunities} />
+                                    ? <OpportunityTable opportunities={sortedOpportunities} />
                                     : <EmptyStatePanel />
                             )}
                         </>
@@ -177,8 +251,8 @@ const HomePage: React.FC = () => {
             <Header />
             <div className="flex flex-1 flex-col lg:flex-row overflow-hidden">
                 <div className="hidden lg:flex" style={{ width: store.sidebarWidth }}>
-                    <Sidebar 
-                        filteredOpportunities={filteredOpportunities} 
+                    <Sidebar
+                        filteredOpportunities={sortedOpportunities}
                         totalOpportunities={totalOpportunities}
                     />
                 </div>
@@ -209,9 +283,9 @@ const HomePage: React.FC = () => {
                             </button>
                         </div>
                         <div className="flex-grow overflow-y-auto">
-                            <Sidebar 
-                                onDispatch={() => setIsMobileSearchPanelOpen(false)} 
-                                filteredOpportunities={filteredOpportunities}
+                            <Sidebar
+                                onDispatch={() => setIsMobileSearchPanelOpen(false)}
+                                filteredOpportunities={sortedOpportunities}
                                 totalOpportunities={totalOpportunities}
                             />
                         </div>

--- a/components/OpportunityTable.tsx
+++ b/components/OpportunityTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAppStore } from '../store/useAppStore.ts';
-import { Opportunity } from '../types.ts';
-import { SearchIcon } from './icons.tsx';
+import { Opportunity, OpportunitySortField } from '../types.ts';
+import { SearchIcon, ArrowDownIcon } from './icons.tsx';
 import OpportunityRow from './common/OpportunityRow.tsx';
 
 
@@ -9,23 +9,101 @@ interface OpportunityTableProps {
     opportunities: Opportunity[];
 }
 
-const TableHeader: React.FC = React.memo(() => (
-    <div className="hidden lg:grid grid-cols-[minmax(0,_3fr)_minmax(0,_1.5fr)_1fr_1fr_1.5fr_1fr] gap-x-6 items-center px-6 py-3 bg-bg-secondary border-b-2 border-border-accent">
-        <div className="text-xs font-medium text-text-secondary uppercase tracking-wider">Opportunity</div>
-        <div className="text-xs font-medium text-text-secondary uppercase tracking-wider">Location</div>
-        <div className="text-xs font-medium text-text-secondary uppercase tracking-wider">Timeline</div>
-        <div className="text-xs font-medium text-text-secondary uppercase tracking-wider text-center">Status</div>
-        <div className="text-xs font-medium text-text-secondary uppercase tracking-wider">Relevance</div>
-        <div className="text-xs font-medium text-text-secondary uppercase tracking-wider text-center">Source</div>
-    </div>
-));
+const SortIndicator: React.FC<{ active: boolean; direction: 'asc' | 'desc' }> = ({ active, direction }) => (
+    <ArrowDownIcon
+        className={`w-4 h-4 transition-transform duration-200 ${direction === 'asc' ? 'rotate-180' : ''} ${active ? 'opacity-100 text-accent' : 'opacity-0 text-border-accent group-hover:opacity-60'}`}
+    />
+);
+
+const columns: { field: OpportunitySortField; label: string; align?: 'center' }[] = [
+    { field: 'title', label: 'Opportunity' },
+    { field: 'location', label: 'Location' },
+    { field: 'deadline', label: 'Timeline' },
+    { field: 'status', label: 'Status', align: 'center' },
+    { field: 'relevance', label: 'Relevance' },
+    { field: 'source', label: 'Source', align: 'center' },
+];
+
+const TableHeader: React.FC = React.memo(() => {
+    const { opportunitySort, setOpportunitySort } = useAppStore(state => ({
+        opportunitySort: state.opportunitySort,
+        setOpportunitySort: state.setOpportunitySort,
+    }));
+
+    return (
+        <div className="hidden lg:grid grid-cols-[minmax(0,_3fr)_minmax(0,_1.5fr)_1fr_1fr_1.5fr_1fr] gap-x-6 items-center px-6 py-3 bg-bg-secondary border-b-2 border-border-accent">
+            {columns.map(({ field, label, align }) => {
+                const isActive = opportunitySort.field === field;
+                const alignmentClasses = align === 'center' ? 'justify-center text-center space-x-1.5' : 'justify-start text-left space-x-2';
+
+                return (
+                    <button
+                        key={field}
+                        type="button"
+                        onClick={() => setOpportunitySort(field)}
+                        className={`group flex items-center ${alignmentClasses} text-xs font-medium uppercase tracking-wider transition-colors duration-200 ${isActive ? 'text-accent' : 'text-text-secondary hover:text-accent'}`}
+                    >
+                        <span>{label}</span>
+                        <SortIndicator active={isActive} direction={opportunitySort.direction} />
+                    </button>
+                );
+            })}
+        </div>
+    );
+});
+
+TableHeader.displayName = 'TableHeader';
+
+const mobileSortOptions: { label: string; field: OpportunitySortField; direction: 'asc' | 'desc' }[] = [
+    { label: 'Relevance (High → Low)', field: 'relevance', direction: 'desc' },
+    { label: 'Relevance (Low → High)', field: 'relevance', direction: 'asc' },
+    { label: 'Deadline (Soonest)', field: 'deadline', direction: 'asc' },
+    { label: 'Deadline (Latest)', field: 'deadline', direction: 'desc' },
+    { label: 'Status (A → Z)', field: 'status', direction: 'asc' },
+    { label: 'Title (A → Z)', field: 'title', direction: 'asc' },
+    { label: 'Location (A → Z)', field: 'location', direction: 'asc' },
+    { label: 'Source (A → Z)', field: 'source', direction: 'asc' },
+];
+
+const MobileSortControl: React.FC = () => {
+    const { opportunitySort, setOpportunitySort } = useAppStore(state => ({
+        opportunitySort: state.opportunitySort,
+        setOpportunitySort: state.setOpportunitySort,
+    }));
+
+    const selectedValue = `${opportunitySort.field}:${opportunitySort.direction}`;
+
+    return (
+        <div className="lg:hidden flex justify-end px-4 pt-4">
+            <label className="flex items-center space-x-2 text-sm text-text-secondary">
+                <span className="font-semibold text-text-primary">Sort</span>
+                <select
+                    value={selectedValue}
+                    onChange={(event) => {
+                        const [field, direction] = event.target.value.split(':') as [OpportunitySortField, 'asc' | 'desc'];
+                        setOpportunitySort(field, direction);
+                    }}
+                    className="bg-bg-secondary border border-border-accent rounded-md py-1.5 px-2 text-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
+                    aria-label="Change opportunity sort order"
+                >
+                    {mobileSortOptions.map((option) => (
+                        <option key={`${option.field}:${option.direction}`} value={`${option.field}:${option.direction}`}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+            </label>
+        </div>
+    );
+};
 
 const OpportunityTable: React.FC<OpportunityTableProps> = ({ opportunities }) => {
 
     return (
         <div className="rounded-lg shadow-lg flex flex-col animate-slide-in-up lg:bg-bg-secondary">
             <TableHeader />
-            
+            <MobileSortControl />
+
             <div className="flex-grow lg:overflow-auto">
                 {opportunities.length > 0 ? (
                      <div className="space-y-3 lg:space-y-0">

--- a/store/uiSlice.ts
+++ b/store/uiSlice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from 'zustand';
 import { produce } from 'immer';
-import { UISlice, RootState, Agent, SearchParams, Toast, Theme } from '../types.ts';
+import { UISlice, RootState, Agent, SearchParams, Toast, Theme, OpportunitySortField } from '../types.ts';
 
 export const createUISlice: StateCreator<
     RootState,
@@ -18,6 +18,7 @@ export const createUISlice: StateCreator<
     isExploratorySearchEnabled: false,
     newlyAddedOpportunityIds: [],
     toasts: [],
+    opportunitySort: { field: 'relevance', direction: 'desc' },
     
     setSidebarWidth: (width) => set({ sidebarWidth: Math.max(320, Math.min(width, 600)) }),
     setLastSearchReport: (report) => set({ lastSearchReport: report }),
@@ -34,6 +35,29 @@ export const createUISlice: StateCreator<
     removeToast: (id) => {
         set(produce((state: RootState) => {
             state.toasts = state.toasts.filter((t: Toast) => t.id !== id);
+        }));
+    },
+    setOpportunitySort: (field, direction) => {
+        const defaultDirections: Record<OpportunitySortField, 'asc' | 'desc'> = {
+            relevance: 'desc',
+            deadline: 'asc',
+            status: 'asc',
+            title: 'asc',
+            organization: 'asc',
+            source: 'asc',
+            location: 'asc',
+        };
+
+        set(produce((state: RootState) => {
+            const currentSort = state.opportunitySort;
+            if (currentSort.field === field && direction === undefined) {
+                currentSort.direction = currentSort.direction === 'asc' ? 'desc' : 'asc';
+            } else {
+                state.opportunitySort = {
+                    field,
+                    direction: direction ?? defaultDirections[field],
+                };
+            }
         }));
     },
     setTheme: (theme) => {

--- a/types.ts
+++ b/types.ts
@@ -92,6 +92,14 @@ export interface AdvancedFilters {
     deadline: { start: string | null; end: string | null };
 }
 
+export type OpportunitySortField = 'relevance' | 'deadline' | 'status' | 'title' | 'organization' | 'source' | 'location';
+export type OpportunitySortDirection = 'asc' | 'desc';
+
+export interface OpportunitySort {
+    field: OpportunitySortField;
+    direction: OpportunitySortDirection;
+}
+
 export interface Agent {
     id:string;
     userId: string;
@@ -202,6 +210,7 @@ export interface UISliceState {
     isExploratorySearchEnabled: boolean;
     newlyAddedOpportunityIds: string[];
     toasts: Toast[];
+    opportunitySort: OpportunitySort;
 }
 export interface UISliceActions {
     setSidebarWidth: (width: number) => void;
@@ -218,6 +227,7 @@ export interface UISliceActions {
     setNewlyAddedOpportunityIds: (ids: string[]) => void;
     addToast: (toast: Omit<Toast, 'id'>) => void;
     removeToast: (id: string) => void;
+    setOpportunitySort: (field: OpportunitySortField, direction?: OpportunitySortDirection) => void;
 }
 export type UISlice = UISliceState & UISliceActions;
 


### PR DESCRIPTION
## Summary
- add global opportunity sort state and expose setter for toggling field and direction
- compute sorted opportunities before rendering dashboards and reuse across sidebar and table
- enhance the opportunity table with clickable header controls and a mobile sort picker

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df6e42077883239c287d48fe3565bc