### PR TITLE
Enhance dashboard filters and performance plan

### DIFF
--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -15,8 +15,9 @@ import OnboardingTour from './OnboardingTour.tsx';
 import AdvancedFiltersPanel from './AdvancedFiltersPanel.tsx';
 import AgentPanel from './AgentPanel.tsx';
 import ToastContainer from './ToastContainer.tsx';
-import { TableCellsIcon, TuneIcon, RobotIcon, CloseIcon } from './icons.tsx';
+import { TableCellsIcon, TuneIcon, RobotIcon, CloseIcon, SearchIcon } from './icons.tsx';
 import EmptyStatePanel from './EmptyStatePanel.tsx';
+import ActiveFiltersSummary from './common/ActiveFiltersSummary.tsx';
 
 const HomePage: React.FC = () => {
     const [isMobileSearchPanelOpen, setIsMobileSearchPanelOpen] = useState(false);
@@ -162,19 +163,31 @@ const HomePage: React.FC = () => {
         }
     }, [store.isAuthenticated, totalOpportunities, store.isAgentSearching]);
     
+    const activeFiltersCount = useMemo(() => {
+        let count = 0;
+        if (store.clientSearchQuery.trim()) count += 1;
+        if (store.advancedFilters.status.length > 0) count += store.advancedFilters.status.length;
+        const [minRelevance, maxRelevance] = store.advancedFilters.relevance;
+        if (minRelevance > 0 || maxRelevance < 100) count += 1;
+        if (store.advancedFilters.deadline.start || store.advancedFilters.deadline.end) count += 1;
+        return count;
+    }, [store.clientSearchQuery, store.advancedFilters]);
+
     const ViewToggle = () => (
-         <div className="flex items-center bg-bg-primary p-1 rounded-full border border-border-accent">
+         <div className="flex items-center bg-bg-primary p-1 rounded-full border border-border-accent shadow-sm">
             <button
                 onClick={() => store.setActiveView('table')}
-                className={`flex items-center space-x-2 text-sm font-semibold px-4 py-1.5 rounded-full transition-colors ${store.activeView === 'table' ? 'bg-accent text-accent-text' : 'text-text-secondary hover:bg-border-accent'}`}
+                aria-pressed={store.activeView === 'table'}
+                className={`flex items-center space-x-2 text-sm font-semibold px-4 py-1.5 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${store.activeView === 'table' ? 'bg-accent text-accent-text shadow-sm' : 'text-text-secondary hover:bg-border-accent'}`}
             >
                 <TableCellsIcon className="w-5 h-5" />
                 <span>Table</span>
             </button>
              {store.hasProFeatures() && (
-                 <button
+                <button
                     onClick={() => store.setActiveView('agents')}
-                    className={`flex items-center space-x-2 text-sm font-semibold px-4 py-1.5 rounded-full transition-colors ${store.activeView === 'agents' ? 'bg-accent text-accent-text' : 'text-text-secondary hover:bg-border-accent'}`}
+                    aria-pressed={store.activeView === 'agents'}
+                    className={`flex items-center space-x-2 text-sm font-semibold px-4 py-1.5 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${store.activeView === 'agents' ? 'bg-accent text-accent-text shadow-sm' : 'text-text-secondary hover:bg-border-accent'}`}
                 >
                     <RobotIcon className="w-5 h-5" />
                     <span>Agents</span>
@@ -209,27 +222,53 @@ const HomePage: React.FC = () => {
                             <InsightsPanel insights={store.insights} isLoading={store.isGeneratingInsights} />
                             
                             <div className="flex flex-col md:flex-row md:items-center md:space-x-4 mb-4" data-tour="filter-bar">
-                                <input
-                                    type="text"
-                                    value={store.clientSearchQuery}
-                                    onChange={(e) => store.setClientSearchQuery(e.target.value)}
-                                    placeholder="Filter results by keyword..."
-                                    className="w-full bg-bg-primary border border-border-accent rounded-md py-2 px-3 text-text-primary focus:ring-2 focus:ring-accent focus:outline-none transition disabled:opacity-50 disabled:cursor-not-allowed"
-                                    disabled={totalOpportunities === 0 && store.activeView !== 'agents'}
-                                />
+                                <div className="relative flex-1">
+                                    <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-text-secondary" />
+                                    <input
+                                        type="text"
+                                        value={store.clientSearchQuery}
+                                        onChange={(e) => store.setClientSearchQuery(e.target.value)}
+                                        placeholder="Filter results by keyword..."
+                                        className="w-full bg-bg-primary border border-border-accent rounded-md py-2 pl-10 pr-3 text-text-primary focus:ring-2 focus:ring-accent focus:outline-none transition disabled:opacity-50 disabled:cursor-not-allowed"
+                                        disabled={totalOpportunities === 0 && store.activeView !== 'agents'}
+                                        aria-label="Filter opportunities by keyword"
+                                    />
+                                </div>
                                  <div className="flex items-center justify-between mt-3 md:mt-0 space-x-2">
                                     <button
                                         onClick={() => setIsFilterPanelOpen(prev => !prev)}
                                         disabled={totalOpportunities === 0}
                                         className="flex-shrink-0 flex items-center space-x-2 bg-border-accent hover:bg-accent-hover text-text-primary font-semibold py-2 px-4 rounded-md transition duration-300 disabled:opacity-50"
+                                        aria-expanded={isFilterPanelOpen}
                                     >
                                         <TuneIcon className="w-5 h-5" />
-                                        <span>Filters</span>
+                                        <span className="flex items-center space-x-2">
+                                            <span>Filters</span>
+                                            {activeFiltersCount > 0 && (
+                                                <span className="inline-flex items-center justify-center rounded-full bg-accent px-2 py-0.5 text-xs font-bold text-accent-text">
+                                                    {activeFiltersCount}
+                                                </span>
+                                            )}
+                                        </span>
                                     </button>
                                      {(totalOpportunities > 0 || store.activeView === 'agents') && <ViewToggle />}
                                 </div>
                             </div>
-                            
+
+                            <div className="mb-3 flex flex-col gap-3">
+                                <div className="flex flex-wrap items-center justify-between text-xs font-medium text-text-secondary uppercase tracking-wide">
+                                    <span>
+                                        Showing <span className="text-text-primary">{sortedOpportunities.length}</span> {sortedOpportunities.length === 1 ? 'opportunity' : 'opportunities'}
+                                    </span>
+                                    {store.isAgentSearching ? (
+                                        <span className="text-accent">Agent is scouting…</span>
+                                    ) : (
+                                        <span>Last updated {new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+                                    )}
+                                </div>
+                                <ActiveFiltersSummary />
+                            </div>
+
                             {isFilterPanelOpen && totalOpportunities > 0 && <AdvancedFiltersPanel />}
 
                             {store.activeView === 'agents' ? (

--- a/components/OpportunityTable.tsx
+++ b/components/OpportunityTable.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { useAppStore } from '../store/useAppStore.ts';
 import { Opportunity, OpportunitySortField } from '../types.ts';
 import { SearchIcon, ArrowDownIcon } from './icons.tsx';
@@ -98,27 +99,97 @@ const MobileSortControl: React.FC = () => {
 };
 
 const OpportunityTable: React.FC<OpportunityTableProps> = ({ opportunities }) => {
+    const [isDesktop, setIsDesktop] = useState(() => {
+        if (typeof window === 'undefined') {
+            return false;
+        }
+        return window.matchMedia('(min-width: 1024px)').matches;
+    });
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        const mediaQuery = window.matchMedia('(min-width: 1024px)');
+        const handler = (event: MediaQueryListEvent) => setIsDesktop(event.matches);
+
+        setIsDesktop(mediaQuery.matches);
+        mediaQuery.addEventListener('change', handler);
+
+        return () => mediaQuery.removeEventListener('change', handler);
+    }, []);
+
+    const parentRef = useRef<HTMLDivElement | null>(null);
+
+    const rowVirtualizer = useVirtualizer({
+        count: opportunities.length,
+        getScrollElement: () => parentRef.current,
+        estimateSize: () => (isDesktop ? 112 : 196),
+        overscan: 8,
+    });
+
+    const virtualRows = rowVirtualizer.getVirtualItems();
+    const shouldVirtualize = useMemo(
+        () => isDesktop && opportunities.length > 40,
+        [isDesktop, opportunities.length],
+    );
 
     return (
         <div className="rounded-lg shadow-lg flex flex-col animate-slide-in-up lg:bg-bg-secondary">
             <TableHeader />
             <MobileSortControl />
 
-            <div className="flex-grow lg:overflow-auto">
-                {opportunities.length > 0 ? (
-                     <div className="space-y-3 lg:space-y-0">
-                        {opportunities.map((op) => (
-                           <OpportunityRow key={op.id} opportunity={op} />
-                        ))}
-                    </div>
-                ) : (
-                    <div className="flex flex-col items-center justify-center h-full text-center py-16 text-text-secondary bg-bg-secondary rounded-lg">
-                        <SearchIcon className="w-12 h-12 text-border-accent" />
-                        <p className="mt-4 font-bold text-lg text-text-primary">No matching opportunities found.</p>
-                        <p className="mt-1">Try adjusting your filters or dispatch the agent for a new search.</p>
-                    </div>
-                )}
-            </div>
+            {opportunities.length > 0 ? (
+                <div ref={parentRef} className="flex-grow lg:overflow-auto">
+                    {shouldVirtualize ? (
+                        <div
+                            style={{
+                                height: rowVirtualizer.getTotalSize(),
+                                position: 'relative',
+                            }}
+                        >
+                            {virtualRows.map((virtualRow) => {
+                                const opportunity = opportunities[virtualRow.index];
+                                const isLast = virtualRow.index === opportunities.length - 1;
+                                return (
+                                    <div
+                                        key={opportunity.id}
+                                        data-index={virtualRow.index}
+                                        ref={rowVirtualizer.measureElement}
+                                        style={{
+                                            position: 'absolute',
+                                            top: 0,
+                                            left: 0,
+                                            width: '100%',
+                                            transform: `translateY(${virtualRow.start}px)`,
+                                            paddingBottom: 12,
+                                        }}
+                                    >
+                                        <OpportunityRow opportunity={opportunity} showDivider={!isLast} />
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    ) : (
+                        <div className="space-y-3 lg:space-y-0">
+                            {opportunities.map((opportunity, index) => (
+                                <OpportunityRow
+                                    key={opportunity.id}
+                                    opportunity={opportunity}
+                                    showDivider={index !== opportunities.length - 1}
+                                />
+                            ))}
+                        </div>
+                    )}
+                </div>
+            ) : (
+                <div className="flex flex-col items-center justify-center h-full text-center py-16 text-text-secondary bg-bg-secondary rounded-lg">
+                    <SearchIcon className="w-12 h-12 text-border-accent" />
+                    <p className="mt-4 font-bold text-lg text-text-primary">No matching opportunities found.</p>
+                    <p className="mt-1">Try adjusting your filters or dispatch the agent for a new search.</p>
+                </div>
+            )}
         </div>
     );
 };

--- a/components/common/ActiveFiltersSummary.tsx
+++ b/components/common/ActiveFiltersSummary.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo } from 'react';
+import { useAppStore } from '../../store/useAppStore.ts';
+import { CloseIcon } from '../icons.tsx';
+
+const formatDate = (dateString: string | null) => {
+    if (!dateString) return null;
+    const parsed = new Date(dateString);
+    if (Number.isNaN(parsed.getTime())) {
+        return null;
+    }
+    return parsed.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    });
+};
+
+const ActiveFiltersSummary: React.FC = () => {
+    const {
+        clientSearchQuery,
+        advancedFilters,
+        setAdvancedFilters,
+        resetAdvancedFilters,
+        setClientSearchQuery,
+    } = useAppStore(state => ({
+        clientSearchQuery: state.clientSearchQuery,
+        advancedFilters: state.advancedFilters,
+        setAdvancedFilters: state.setAdvancedFilters,
+        resetAdvancedFilters: state.resetAdvancedFilters,
+        setClientSearchQuery: state.setClientSearchQuery,
+    }));
+
+    const activeFilters = useMemo(() => {
+        const items: { key: string; label: string; onRemove: () => void }[] = [];
+        const trimmedQuery = clientSearchQuery.trim();
+
+        if (trimmedQuery) {
+            items.push({
+                key: 'search',
+                label: `Keyword: "${trimmedQuery}"`,
+                onRemove: () => setClientSearchQuery(''),
+            });
+        }
+
+        if (advancedFilters.status.length > 0) {
+            advancedFilters.status.forEach((status) => {
+                items.push({
+                    key: `status-${status}`,
+                    label: status,
+                    onRemove: () => setAdvancedFilters({
+                        status: advancedFilters.status.filter((value) => value !== status),
+                    }),
+                });
+            });
+        }
+
+        const [minRelevance, maxRelevance] = advancedFilters.relevance;
+        if (minRelevance > 0 || maxRelevance < 100) {
+            const parts: string[] = [];
+            if (minRelevance > 0) parts.push(`≥ ${minRelevance}`);
+            if (maxRelevance < 100) parts.push(`≤ ${maxRelevance}`);
+            items.push({
+                key: 'relevance',
+                label: `Relevance ${parts.join(' & ')}`,
+                onRemove: () => setAdvancedFilters({ relevance: [0, 100] }),
+            });
+        }
+
+        const { start, end } = advancedFilters.deadline;
+        const formattedStart = formatDate(start);
+        const formattedEnd = formatDate(end);
+        if (formattedStart || formattedEnd) {
+            items.push({
+                key: 'deadline',
+                label: `Deadline ${formattedStart ?? 'Any'} → ${formattedEnd ?? 'Any'}`,
+                onRemove: () => setAdvancedFilters({ deadline: { start: null, end: null } }),
+            });
+        }
+
+        return items;
+    }, [advancedFilters, clientSearchQuery, setAdvancedFilters, setClientSearchQuery]);
+
+    if (activeFilters.length === 0) {
+        return null;
+    }
+
+    const clearAll = () => {
+        resetAdvancedFilters();
+        setClientSearchQuery('');
+    };
+
+    return (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border-accent bg-bg-secondary px-3 py-2 text-sm text-text-secondary">
+            <span className="font-semibold text-text-primary">Active filters</span>
+            {activeFilters.map((filter) => (
+                <button
+                    key={filter.key}
+                    type="button"
+                    onClick={filter.onRemove}
+                    className="inline-flex items-center space-x-2 rounded-full border border-border-accent bg-bg-primary px-3 py-1 text-xs font-semibold text-text-primary transition-colors hover:border-accent hover:text-accent"
+                >
+                    <span>{filter.label}</span>
+                    <CloseIcon className="h-3.5 w-3.5" />
+                </button>
+            ))}
+            <button
+                type="button"
+                onClick={clearAll}
+                className="ml-auto text-xs font-semibold uppercase tracking-wide text-accent hover:underline"
+            >
+                Clear all
+            </button>
+        </div>
+    );
+};
+
+export default ActiveFiltersSummary;

--- a/components/common/OpportunityRow.tsx
+++ b/components/common/OpportunityRow.tsx
@@ -25,16 +25,18 @@ const RelevanceIndicator: React.FC<{ score: number }> = React.memo(({ score }) =
 
 interface OpportunityRowProps {
     opportunity: Opportunity;
+    showDivider?: boolean;
+    className?: string;
 }
 
-const OpportunityRow: React.FC<OpportunityRowProps> = ({ opportunity }) => {
+const OpportunityRow: React.FC<OpportunityRowProps> = ({ opportunity, showDivider = true, className = '' }) => {
     const { newlyAddedOpportunityIds } = useAppStore(state => ({
         newlyAddedOpportunityIds: state.newlyAddedOpportunityIds,
     }));
     const { openModal } = useModal();
     const daysLeft = calculateDaysLeft(opportunity.Deadline);
     const isNew = newlyAddedOpportunityIds.includes(opportunity.id);
-    
+
     const isValidDocUrl = opportunity.URL && opportunity.URL.startsWith('http');
     const isValidNoticeUrl = opportunity.noticePageUrl && opportunity.noticePageUrl.startsWith('http');
 
@@ -61,10 +63,41 @@ const OpportunityRow: React.FC<OpportunityRowProps> = ({ opportunity }) => {
         </div>
     );
 
+    const rowClasses = [
+        className,
+        'bg-bg-secondary',
+        'rounded-lg',
+        'shadow-md',
+        'p-4',
+        'animate-fade-in',
+        'border',
+        'border-border-accent',
+        'hover:border-accent',
+        'transition-colors',
+        'duration-200',
+        'cursor-pointer',
+        'lg:border-x-0',
+        'lg:border-t-0',
+        'lg:rounded-none',
+        'lg:p-0',
+        'lg:bg-transparent',
+        'lg:hover:bg-border-accent',
+    ];
+
+    if (showDivider) {
+        rowClasses.push('lg:border-b');
+    } else {
+        rowClasses.push('lg:border-b-0');
+    }
+
+    if (isNew) {
+        rowClasses.push('glow-fade-out');
+    }
+
     return (
-        <div 
+        <div
             onClick={() => openModal('opportunityDetail', { opportunity })}
-            className={`bg-bg-secondary rounded-lg shadow-md p-4 animate-fade-in border border-border-accent hover:border-accent transition-colors duration-200 cursor-pointer lg:border-b lg:border-x-0 lg:border-t-0 lg:rounded-none lg:p-0 lg:bg-transparent lg:hover:bg-border-accent ${isNew ? 'glow-fade-out' : ''}`}
+            className={rowClasses.filter(Boolean).join(' ')}
         >
              {/* --- Desktop Layout --- */}
             <div className="hidden lg:grid grid-cols-[minmax(0,_3fr)_minmax(0,_1.5fr)_1fr_1fr_1.5fr_1fr] gap-x-6 items-center px-6 py-4">

--- a/docs/next-level-plan.md
+++ b/docs/next-level-plan.md
@@ -1,0 +1,55 @@
+# ProScout Next-Level Strategy
+
+## Vision
+ProScout becomes the go-to control center for business development teams, automating opportunity discovery, triage, and collaboration so that every search session produces qualified leads without busywork.
+
+## Product Pillars
+1. **Intelligent Discovery** – Blend AI scouting with human control, ensuring high-signal opportunities appear faster than manual research.
+2. **Insightful Decisioning** – Present scoring, risk, and context clearly so teams can act with confidence.
+3. **Workflow Acceleration** – Streamline follow-up actions (assign, draft responses, save searches) inside the app.
+
+## 12-Week Roadmap
+### Phase 1 (Weeks 1–4): Foundation & Speed
+- Instrument core journeys (search, triage, save) with analytics.
+- Ship UI performance optimizations (virtualized lists, lighter renders, cache warmers).
+- Introduce responsive design refinements and accessibility polish.
+- Add advanced filter summaries so users understand and manage active constraints quickly.
+
+### Phase 2 (Weeks 5–8): Assisted Intelligence
+- Expand AI scouting prompts with sector presets and regional focus controls.
+- Deliver context-rich opportunity pages (comparable tenders, recommended next steps).
+- Launch collaborative notes and mentions tied to opportunities.
+- Layer in timeline visualizations (Gantt/deadline heatmaps) for portfolio planning.
+
+### Phase 3 (Weeks 9–12): Automation & Growth
+- Roll out saved-search automation with schedule-based agent dispatch and alerts.
+- Provide CRM integrations (HubSpot, Salesforce) and export recipes.
+- Add billing insights (usage, ROI) and in-app upgrade nudges.
+- Launch onboarding playbooks with interactive walkthroughs tailored to user roles.
+
+## UX & UI Enhancements
+- **Unified Filter Bar**: contextual search, chip-based active filters, and quick clear actions.
+- **Progressive Disclosure**: emphasize insights first, collapse dense tables until needed, and introduce micro-interactions for state changes.
+- **Design System Tokens**: codify spacing, color, and typography to keep future features consistent.
+- **Responsive Layouts**: optimized navigation for mobile dispatch flow, sticky action rows, and touch-friendly controls.
+
+## Performance & Reliability
+- Virtualize long opportunity lists (>40 rows) to keep interactions smooth.
+- Memoize store selectors and throttle expensive computations where practical.
+- Preload agent assets and cache API responses in IndexedDB for offline resilience.
+- Add structured loading states, skeletons, and health diagnostics (latency, success rate).
+
+## Operational Excellence
+- Establish automated regression suite (unit + e2e) and visual snapshots for UI stability.
+- Define release checklist (performance budget, accessibility audit, localization review).
+- Monitor key KPIs: time-to-qualified lead, agent success rate, retention cohorts.
+
+## Success Metrics
+- 30% reduction in time spent triaging 100 opportunities.
+- 2× increase in searches saved and automated dispatches per account.
+- NPS ≥ 45 driven by clearer insights and faster response workflow.
+
+## Next Steps
+1. Finish instrumentation + dashboards for baseline metrics.
+2. Partner with 3 beta teams to validate the assisted intelligence features.
+3. Prioritize integration backlog based on customer ARR impact.


### PR DESCRIPTION
## Summary
- document a 12-week next-level product strategy covering UX, intelligence, and automation priorities
- upgrade the dashboard filter experience with search affordances, active filter chips, and clearer result counts
- virtualize the opportunity table for desktop users and make rows reusable to keep large lists responsive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39710cf4c8323b719ccf3e777f752